### PR TITLE
Adding BigQuery roles in the initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Please make sure that you have selected a Google Cloud project as shown below:
   gcloud projects add-iam-policy-binding $PROJECT_ID \
         --member="serviceAccount:${PROJECT_NUM}-compute@developer.gserviceaccount.com"\
         --role='roles/storage.admin'
+  gcloud projects add-iam-policy-binding $PROJECT_ID \
+        --member="serviceAccount:${PROJECT_NUM}-compute@developer.gserviceaccount.com"\
+        --role='roles/bigquery.user'
+  gcloud projects add-iam-policy-binding $PROJECT_ID \
+        --member="serviceAccount:${PROJECT_NUM}-compute@developer.gserviceaccount.com"\
+        --role='roles/bigquery.jobUser'
   ```
 
 #### Step 2: Create a User-Managed Notebook instance on Vertex AI Workbench

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Please make sure that you have selected a Google Cloud project as shown below:
   gcloud pubsub subscriptions create "ff-tx-sub" --topic="ff-tx" --topic-project="cymbal-fraudfinder"
   gcloud pubsub subscriptions create "ff-txlabels-sub" --topic="ff-txlabels" --topic-project="cymbal-fraudfinder"
   
-  # Run the following command to grant the Compute Engine default service account access to read and write pipeline artifacts in Google Cloud Storage.
+  # Run the following command to grant the Compute Engine default service account access to read and write pipeline artifacts in Google Cloud Storage as well as create the BigQuery tables for the notebook 00_environment_setup.ipynb.
   PROJECT_ID=$(gcloud config get-value project)
   PROJECT_NUM=$(gcloud projects list --filter="$PROJECT_ID" --format="value(PROJECT_NUMBER)")
   gcloud projects add-iam-policy-binding $PROJECT_ID \


### PR DESCRIPTION
Without the BigQuery permissions bigquery.datasets.create and bigquery.jobs.create attached to the compute Service Account, the shell command "!python3 scripts/copy_bigquery_data.py $BUCKET_NAME" in the notebook "00_environment_setup.ipynb" fails because the Service Account is not authorized to create the BigQuery datasets and tables.
For that reason, I had to assign the following roles to the Service Account:

BigQuery Job User
BigQuery User