### PR TITLE
Qwiklab patch

### DIFF
--- a/00_environment_setup.ipynb
+++ b/00_environment_setup.ipynb
@@ -577,13 +577,6 @@
     "\n",
     "Now you can go to the next notebook `01_exploratory_data_analysis.ipynb`"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -594,9 +587,9 @@
   },
   "environment": {
    "kernel": "python3",
-   "name": "common-cpu.m103",
+   "name": "common-cpu.m104",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m103"
+   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m104"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/01_exploratory_data_analysis.ipynb
+++ b/01_exploratory_data_analysis.ipynb
@@ -535,13 +535,6 @@
     "\n",
     "Now you can go to the next notebook `02_feature_engineering_batch.ipynb`"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -552,9 +545,9 @@
   },
   "environment": {
    "kernel": "python3",
-   "name": "common-cpu.m103",
+   "name": "common-cpu.m104",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m103"
+   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m104"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/02_feature_engineering_batch.ipynb
+++ b/02_feature_engineering_batch.ipynb
@@ -953,9 +953,9 @@
     "    customer_entity_type = ff_feature_store.get_entity_type(entity_type_id=CUSTOMER_ENTITY_ID)\n",
     "except:\n",
     "    # else, create entity type\n",
-    "customer_entity_type = ff_feature_store.create_entity_type(\n",
-    "    entity_type_id=CUSTOMER_ENTITY_ID, description=\"Customer Entity\", sync=True\n",
-    ")"
+    "    customer_entity_type = ff_feature_store.create_entity_type(\n",
+    "        entity_type_id=CUSTOMER_ENTITY_ID, description=\"Customer Entity\", sync=True\n",
+    "    )"
    ]
   },
   {

--- a/02_feature_engineering_batch.ipynb
+++ b/02_feature_engineering_batch.ipynb
@@ -357,7 +357,7 @@
    "outputs": [],
    "source": [
     "create_customer_batch_features_query = f\"\"\"\n",
-    "CREATE OR REPLACE TABLE {CUSTOMERS_BQ_TABLE_URI} AS\n",
+    "CREATE OR REPLACE TABLE `{CUSTOMERS_BQ_TABLE_URI}` AS\n",
     "WITH\n",
     "  -- query to join labels with features -------------------------------------------------------------------------------------------\n",
     "  get_raw_table AS (\n",
@@ -479,7 +479,7 @@
    "outputs": [],
    "source": [
     "create_terminal_batch_features_query = f\"\"\"\n",
-    "CREATE OR REPLACE TABLE {TERMINALS_BQ_TABLE_URI} AS\n",
+    "CREATE OR REPLACE TABLE `{TERMINALS_BQ_TABLE_URI}` AS\n",
     "WITH\n",
     "  -- query to join labels with features -------------------------------------------------------------------------------------------\n",
     "  get_raw_table AS (\n",
@@ -903,13 +903,19 @@
    },
    "outputs": [],
    "source": [
-    "# Try to create a new featurestore resource\n",
-    "ff_feature_store = Featurestore.create(\n",
-    "    featurestore_id=f\"{FEATURESTORE_ID}\",\n",
-    "    online_store_fixed_node_count=ONLINE_STORAGE_NODES,\n",
-    "    labels={\"team\": \"cymbal_bank\", \"app\": \"fraudfinder\"},\n",
-    "    sync=True,\n",
-    ")"
+    "try:\n",
+    "    # Checks if there is already a Featurestore\n",
+    "    ff_feature_store = vertex_ai.Featurestore(f\"{FEATURESTORE_ID}\")\n",
+    "    print(f\"\"\"The feature store {FEATURESTORE_ID} already exists.\"\"\")\n",
+    "except:\n",
+    "    # Creates a Featurestore\n",
+    "    print(f\"\"\"Creating new feature store {FEATURESTORE_ID}.\"\"\")\n",
+    "    ff_feature_store = Featurestore.create(\n",
+    "        featurestore_id=f\"{FEATURESTORE_ID}\",\n",
+    "        online_store_fixed_node_count=ONLINE_STORAGE_NODES,\n",
+    "        labels={\"team\": \"cymbal_bank\", \"app\": \"fraudfinder\"},\n",
+    "        sync=True,\n",
+    "    )"
    ]
   },
   {
@@ -942,6 +948,11 @@
    },
    "outputs": [],
    "source": [
+    "try:\n",
+    "    # get entity type, if it already exists\n",
+    "    customer_entity_type = ff_feature_store.get_entity_type(entity_type_id=CUSTOMER_ENTITY_ID)\n",
+    "except:\n",
+    "    # else, create entity type\n",
     "customer_entity_type = ff_feature_store.create_entity_type(\n",
     "    entity_type_id=CUSTOMER_ENTITY_ID, description=\"Customer Entity\", sync=True\n",
     ")"
@@ -1054,11 +1065,17 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "Pje6CLgj3t46"
+    "id": "Pje6CLgj3t46",
+    "tags": []
    },
    "outputs": [],
    "source": [
-    "terminal_entity_type = ff_feature_store.create_entity_type(\n",
+    "try:\n",
+    "    # get entity type, if it already exists\n",
+    "    terminal_entity_type = ff_feature_store.get_entity_type(entity_type_id=TERMINAL_ENTITY_ID)\n",
+    "except:\n",
+    "    # else, create entity type\n",
+    "    terminal_entity_type = ff_feature_store.create_entity_type(\n",
     "    entity_type_id=TERMINAL_ENTITY_ID, description=\"Terminal Entity\", sync=True\n",
     ")"
    ]
@@ -1387,9 +1404,9 @@
   },
   "environment": {
    "kernel": "python3",
-   "name": "common-cpu.m103",
+   "name": "common-cpu.m104",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m103"
+   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m104"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/bqml/04_model_training_and_prediction.ipynb
+++ b/bqml/04_model_training_and_prediction.ipynb
@@ -385,7 +385,7 @@
    "outputs": [],
    "source": [
     "read_instances_query = f\"\"\"\n",
-    "CREATE OR REPLACE TABLE {PROJECT_ID}.tx.{READ_INSTANCES_TABLE} as (\n",
+    "CREATE OR REPLACE TABLE `{PROJECT_ID}.tx.{READ_INSTANCES_TABLE}` as (\n",
     "    SELECT\n",
     "        raw_tx.TX_TS AS timestamp,\n",
     "        raw_tx.CUSTOMER_ID AS customer,\n",
@@ -404,7 +404,7 @@
     "print(read_instances_query)\n",
     "\n",
     "run_bq_query(read_instances_query)\n",
-    "run_bq_query(f\"SELECT * FROM {PROJECT_ID}.tx.{READ_INSTANCES_TABLE} LIMIT 10\")"
+    "run_bq_query(f\"SELECT * FROM `{PROJECT_ID}.tx.{READ_INSTANCES_TABLE}` LIMIT 10\")"
    ]
   },
   {
@@ -1128,9 +1128,9 @@
   },
   "environment": {
    "kernel": "python3",
-   "name": "common-cpu.m103",
+   "name": "common-cpu.m104",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m103"
+   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m104"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/bqml/05_model_training_pipeline_formalization.ipynb
+++ b/bqml/05_model_training_pipeline_formalization.ipynb
@@ -581,9 +581,9 @@
   },
   "environment": {
    "kernel": "python3",
-   "name": "common-cpu.m103",
+   "name": "common-cpu.m104",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m103"
+   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m104"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/bqml/06_model_deployment.ipynb
+++ b/bqml/06_model_deployment.ipynb
@@ -160,7 +160,7 @@
     "BQ_DATASET = \"tx\"\n",
     "END_DATE_TRAIN = (datetime.today() - timedelta(days=1)).strftime(\"%Y-%m-%d\")\n",
     "TRAIN_TABLE_NAME = f\"train_table_{END_DATE_TRAIN.replace('-', '')}\"\n",
-    "BQML_MODEL_ID = f\"{PROJECT_ID}.{BQ_DATASET}.{MODEL_NAME}_pipeline\"\n",
+    "BQML_MODEL_ID = f\"{PROJECT_ID}.{BQ_DATASET}.{MODEL_NAME}\"\n",
     "MODEL_ARTIFACT_URI = f\"gs://{BUCKET_NAME}/deliverables/{MODEL_NAME}\"\n",
     "DEPLOY_VERSION = \"tf2-cpu.2-5\"\n",
     "DEPLOY_IMAGE = \"{}-docker.pkg.dev/vertex-ai/prediction/{}:latest\".format(\n",
@@ -644,9 +644,9 @@
   },
   "environment": {
    "kernel": "python3",
-   "name": "common-cpu.m103",
+   "name": "common-cpu.m104",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m103"
+   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m104"
   },
   "kernelspec": {
    "display_name": "Python 3",


### PR DESCRIPTION
Fixes to enable FraudFinder to work in the Qwiklabs environment
- backticks to BQ tables
- making 02 notebook more robust to accidental re-executions, where previously, the notebook would break if it were executed more than once by accident