### PR TITLE
Fix Model Training Bugs

### DIFF
--- a/vertex_ai/05_model_training_xgboost_formalization.ipynb
+++ b/vertex_ai/05_model_training_xgboost_formalization.ipynb
@@ -348,7 +348,7 @@
    "outputs": [],
    "source": [
     "sql_query = f\"\"\"\n",
-    "CREATE OR REPLACE TABLE {PROJECT_ID}.tx.{READ_INSTANCES_TABLE} as (\n",
+    "CREATE OR REPLACE TABLE `{PROJECT_ID}.tx.{READ_INSTANCES_TABLE}` as (\n",
     "    SELECT\n",
     "        raw_tx.TX_TS AS timestamp,\n",
     "        raw_tx.CUSTOMER_ID AS customer,\n",
@@ -1009,7 +1009,7 @@
     "\n",
     "\n",
     "endpoint = model.deploy(\n",
-    "    deployed_model_display_name=ENDPOINT_NAME,\n",
+    "    deployed_model_display_name=MODEL_NAME,\n",
     "    traffic_split=TRAFFIC_SPLIT,\n",
     "    machine_type=DEPLOY_COMPUTE,\n",
     "    accelerator_count=0,\n",


### PR DESCRIPTION
Fixing bugs in the vertex_ai/05_model_training_xgboost_formalization.ipynb notebook.

1. Missing SQL query backticks during creation of new BigQuery table name.
2. Changing ENDPOINT_NAME to MODEL_NAME when deploying model to endpoint so that the endpoint connects to the model and deployment is successful